### PR TITLE
Set output command is deprecated

### DIFF
--- a/.github/workflows/03-release.yml
+++ b/.github/workflows/03-release.yml
@@ -12,9 +12,7 @@ jobs:
     steps:
       - name: Checkout Library Repository
         uses: actions/checkout@master
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
+      - name: Ensure that all necessary packages for the workflow are installed before proceeding
+        run: sudo make packages
       - name: Build a binary wheel, a source tarball, and publish distribution 📦 to PyPI
         run: make TOKEN=${{ secrets.PYPI_API_TOKEN }} release

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ ifeq ($(filter $(DISTRIBUTION_CODENAME),$(SUPPORTED_DISTRIBUTIONS)),)
     $(warning Terminating on detection of unsupported Ubuntu distribution: $(DISTRIBUTION_CODENAME). \
     Supported distibutions are: $(SUPPORTED_DISTRIBUTIONS))
 endif
-utilities: packages /usr/bin/swipl /usr/bin/python
+utilities: packages /usr/bin/swipl
 
 .PHONY: packages  ## Install packages required for the tool (Run with sudo)
 packages:
-	sudo apt-get update
-	apt-get -qqy install git bumpversion build-essential software-properties-common jq
+	@sudo apt-get update
+	@apt-get -qqy install git bumpversion build-essential software-properties-common jq python3-venv python3-pip
 
 PROLOG_LIST_FILE = /etc/apt/sources.list.d/swi-prolog-ubuntu-stable-$(DISTRIBUTION_CODENAME).list
 /usr/bin/swipl: $(PROLOG_LIST_FILE)

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ PACK_PATH = ${HOME}/.local/share/swi-prolog/pack
 install: packs
 
 
-.PHONY: packs ## Install the required packs
+.PHONY: packs ## Install the required packs. Override abbreviated_dates version with: make VERSION=v0.0.? packs
 PACK_PATH = ${HOME}/.local/share/swi-prolog/pack
 packs: $(PACK_PATH)/tap  $(PACK_PATH)/date_time $(PACK_PATH)/abbreviated_dates
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,13 @@ $(GH_KEYRING):
 	@apt-get -qqy install $(notdir $@)
 	@touch $@
 
+.PHONY: clean-utilities ## Test utilities installation with: sudo make clean-utilities utilities && make test
+clean-utilities:
+	@apt-get --purge -qqy autoremove swi-prolog-nox bumpversion python3-venv python3-pip
+	@add-apt-repository --remove -y ppa:swi-prolog/stable
+	@rm -f /etc/apt/sources.list.d/swi-prolog-ubuntu-stable-$(DISTRIBUTION_CODENAME).list
+	@apt-get -y autoremove
+
 #
 # Unprivileged user rules
 #
@@ -139,10 +146,6 @@ clean:
 clean-more: clean /usr/bin/swipl
 	@rm -rfd $(VENV)
 	@swipl -g "(member(P,[abbreviated_dates,date_time,tap]),pack_property(P,library(P)),pack_remove(P),fail);true,halt"
-	@apt-get --purge -qqy autoremove swi-prolog-nox bumpversion
-	@add-apt-repository --remove -y ppa:swi-prolog/stable
-	@rm -f /etc/apt/sources.list.d/swi-prolog-ubuntu-stable-$(DISTRIBUTION_CODENAME).list
-	@apt-get -y autoremove
 
 .PHONY: committer ## config committer credentials
 committer:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ VENV = venv
 PYTHON_PATH = $(VENV)/bin
 PYTHON = $(PYTHON_PATH)/python3
 test: $(PYTHON_PATH)/pytest install
-	@$(PYTHON) -m pytest
+	@$(PYTHON) -m pytest -p no:cacheprovider
 
 $(PYTHON_PATH)/%: $(VENV)/bin/activate # Install packages from default repo
 	@$(PYTHON) -m pip install $(notdir $@)
@@ -138,12 +138,8 @@ uninstall: $(PYTHON_PATH)/$(NAME)
 
 
 .PHONY: clean ## Remove debris from build target
-clean:
-	@python3 setup.py clean --all
-	@rm -rfd fuzzy_parser.egg-info/ dist/ __pycache__
-
-.PHONY: clean-more ## Remove also utilities
-clean-more: clean /usr/bin/swipl
+clean:  /usr/bin/swipl
+	@rm -rfd fuzzy_parser.egg-info/ dist/ .pytest_cache/ __pycache__
 	@rm -rfd $(VENV)
 	@swipl -g "(member(P,[abbreviated_dates,date_time,tap]),pack_property(P,library(P)),pack_remove(P),fail);true,halt"
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: help
 .PHONY: help  ## Print this help
 help: about
 	@printf '\n\033[1;36m%-12s\033[0m %s\n────────────────────────\n' "Command" "Description"
-	@awk 'BEGIN {FS = " *## |: "}; /^.PHONY: /{printf "\033[1;36m%-12s\033[0m %s\n", $$2, $$3}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = " *## |: "}; /^.PHONY: /{printf "\033[1;36m%-15s\033[0m %s\n", $$2, $$3}' $(MAKEFILE_LIST)
 
 .PHONY: about  ## Describe this tool
 NAME = 'fuzzy_parser'

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ PROLOG_LIST_FILE = /etc/apt/sources.list.d/swi-prolog-ubuntu-stable-$(DISTRIBUTI
 	@apt-get -qqy install swi-prolog-nox
 	@touch $@
 $(PROLOG_LIST_FILE):
-	apt-add-repository -y ppa:swi-prolog/stable
+	@apt-add-repository -y ppa:swi-prolog/stable
 	@touch $@
 
 ARCH=$(shell dpkg --print-architecture)
@@ -86,7 +86,7 @@ $(PYTHON_PATH)/%: $(VENV)/bin/activate # Install packages from default repo
 	@$(PYTHON) -m pip install $(notdir $@)
 
 $(VENV)/bin/activate: requirements.txt
-	test -d $(VENV) || python3 -m venv $(VENV)
+	@test -d $(VENV) || python3 -m venv $(VENV)
 	@$(PYTHON) -m pip install --upgrade pip
 	@$(PYTHON) -m pip install --use-pep517 -r requirements.txt
 	@touch $@
@@ -94,7 +94,7 @@ $(VENV)/bin/activate: requirements.txt
 
 .PHONY: store-token ## Store the Github token
 store-token:
-	secret-tool store --label='github.com/crgz' user ${USER} domain github.com
+	@secret-tool store --label='github.com/crgz' user ${USER} domain github.com
 
 .PHONY: bump ## Increase the version number
 bump: export GH_TOKEN ?= $(shell secret-tool lookup user ${USER} domain github.com) # Overridable


### PR DESCRIPTION
**Description**

As per the [recent announcement on the GitHub blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), the save-state and set-output commands will be deprecated in GitHub Actions. This will affect any workflow that currently uses these commands and may cause issues with their functionality.

We need to create a plan to address this issue and ensure that our workflow is not impacted by the deprecation of these commands. Possible solutions could include updating our workflow to use alternative commands or finding a way to work around the deprecation.

We should also keep an eye on the official GitHub documentation and any updates regarding the deprecation of these commands to ensure we are fully prepared for the change.

**Current Code**

```yaml
jobs:
    ...
    steps:
      ...
      - name: Set up Python 3.10
        uses: actions/setup-python@v3
        with:
          python-version: "3.10"

```


**Affected Workflows**

-  [fuzzy_dates/release](https://github.com/crgz/fuzzy_dates/blob/master/.github/workflows/03-release.yml)


**Steps to Reproduce**

1. Create a new test branch
2. Push it to GitHub
3. Create a Pull Request
4. Label it with the release label
5. Go to the Actions tab
6. Expand the "Set up Python 3.10" section
7. Read the output

**Expected Behavior**

Run actions/setup-python@v3
Successfully setup CPython (3.10.9)

**Actual Behavior**

Setting up a python environment in Actions reveals this warning:

```
Run actions/setup-python@v3
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Successfully setup CPython (3.10.9)
```

**Screenshots/Error Messages**

![image.png](https://zenhub.dc.zalan.do/images/5c90c02b932dc41e1e274220/f831204a-ea2a-4841-a95f-38c347502c61)

Tags: deprecation, save-state, set-output, GitHub Actions

**Tasks**

- [x] Update the workflow to use alternative commands as a way to work around the deprecation by replacing the action "setup-python@v3" with a Makefile target.

Benefits:
- Prevent potential future deprecation warnings
- Ensure consistency in your workflow.
